### PR TITLE
Improve audio reactivity and fix WaveFlow fract error

### DIFF
--- a/patterns/AuroraBands.js
+++ b/patterns/AuroraBands.js
@@ -1,15 +1,21 @@
 export var frequencyData = array(32);
-var t;
+var t, bass, mid, treble;
 
 export function beforeRender(delta) {
-  t = time(0.02);
+  bass = (frequencyData[0] + frequencyData[1] + frequencyData[2]) / 3;
+  mid = 0;
+  for (var i = 8; i < 20; i++) mid += frequencyData[i];
+  mid /= 12;
+  treble = 0;
+  for (var j = 20; j < 32; j++) treble += frequencyData[j];
+  treble /= 12;
+  t = time(0.02 + treble * 0.02);
 }
 
 export function render3D(index, x, y, z) {
   var angle = (atan2(y, x) + PI) / (2 * PI);
-  var hue = angle * 3 + t;
-  var mid = 0;
-  for (var i = 8; i < 20; i++) mid += frequencyData[i];
-  var v = min(1, mid);
+  var hue = angle * 3 + t + bass;
+  var band = sin((z / 16 + t * 2) * PI * 2) * 0.5 + 0.5;
+  var v = band * min(1, mid);
   hsv(hue, 1, v);
 }

--- a/patterns/BassRipple.js
+++ b/patterns/BassRipple.js
@@ -1,14 +1,25 @@
 export var frequencyData = array(32);
-var t;
+var t, bass, mid, treble;
+
+function fract(x) {
+  return x - floor(x);
+}
 
 export function beforeRender(delta) {
-  t = time(0.05);
+  bass = (frequencyData[0] + frequencyData[1] + frequencyData[2]) / 3;
+  mid = 0;
+  for (var i = 8; i < 20; i++) mid += frequencyData[i];
+  mid /= 12;
+  treble = 0;
+  for (var j = 20; j < 32; j++) treble += frequencyData[j];
+  treble /= 12;
+  t = time(0.05 + bass * 0.05);
 }
 
 export function render3D(index, x, y, z) {
-  var bass = frequencyData[0] + frequencyData[1] + frequencyData[2];
   var height = z / 16;
-  var wave = abs(fract(height * 4 - t * bass) - 0.5) * 2;
-  var v = (1 - wave) * min(1, bass);
-  hsv(height, 1, v);
+  var wave = abs(fract(height * (2 + treble * 4) - t) - 0.5) * 2;
+  var v = (1 - wave) * bass;
+  var hue = height + mid;
+  hsv(hue, 1, min(1, v));
 }

--- a/patterns/BeatFlash.js
+++ b/patterns/BeatFlash.js
@@ -1,15 +1,18 @@
 export var frequencyData = array(32);
 var flash = 0;
-var t;
+var t, bass, treble;
 
 export function beforeRender(delta) {
-  var vol = 0;
-  for (var i = 0; i < 32; i++) vol += frequencyData[i];
-  flash = max(flash - delta / 400, vol);
-  t = time(0.02);
+  bass = (frequencyData[0] + frequencyData[1] + frequencyData[2]) / 3;
+  treble = 0;
+  for (var i = 20; i < 32; i++) treble += frequencyData[i];
+  treble /= 12;
+  flash = max(flash - delta / 400, bass);
+  t = time(0.02 + treble * 0.05);
 }
 
 export function render3D(index, x, y, z) {
   var angle = (atan2(y, x) + PI) / (2 * PI);
-  hsv(angle + t, 1, min(1, flash));
+  var hue = angle + t + treble;
+  hsv(hue, 1, flash);
 }

--- a/patterns/HelixBeats.js
+++ b/patterns/HelixBeats.js
@@ -1,14 +1,18 @@
 export var frequencyData = array(32);
-var t;
+var t, bass, mid, treble;
 
 export function beforeRender(delta) {
-  t = time(0.03);
+  bass = (frequencyData[0] + frequencyData[1] + frequencyData[2]) / 3;
+  mid = frequencyData[5] + frequencyData[6] + frequencyData[7] + frequencyData[8];
+  treble = 0;
+  for (var i = 20; i < 32; i++) treble += frequencyData[i];
+  treble /= 12;
+  t = time(0.03 + bass * 0.04);
 }
 
 export function render3D(index, x, y, z) {
   var angle = (atan2(y, x) + PI) / (2 * PI);
-  var mid = frequencyData[5] + frequencyData[6] + frequencyData[7] + frequencyData[8];
-  var hue = angle * 2 + z / 16 - t;
+  var hue = angle * 2 + z / 16 - t + treble;
   var v = min(1, mid * 1.5);
   hsv(hue, 1, v);
 }

--- a/patterns/PulseTunnel.js
+++ b/patterns/PulseTunnel.js
@@ -1,14 +1,22 @@
 export var frequencyData = array(32);
-var t;
+var t, bass, mid;
+
+function fract(x) {
+  return x - floor(x);
+}
 
 export function beforeRender(delta) {
-  t = time(0.05);
+  bass = (frequencyData[0] + frequencyData[1] + frequencyData[2]) / 3;
+  mid = 0;
+  for (var i = 8; i < 20; i++) mid += frequencyData[i];
+  mid /= 12;
+  t = time(0.05 + bass * 0.05);
 }
 
 export function render3D(index, x, y, z) {
   var angle = (atan2(y, x) + PI) / (2 * PI);
-  var bass = frequencyData[0] + frequencyData[1] + frequencyData[2];
-  var dist = abs(fract(angle - t) - 0.5) * 2;
-  var v = max(0, 1 - dist * 4) * min(1, bass);
-  hsv(angle, 1, v);
+  var dist = abs(fract(angle * 3 - t) - 0.5) * 2;
+  var hue = angle + mid;
+  var v = max(0, 1 - dist * 4) * bass;
+  hsv(hue, 1, v);
 }

--- a/patterns/RainbowVortex.js
+++ b/patterns/RainbowVortex.js
@@ -1,14 +1,17 @@
 export var frequencyData = array(32);
-var t;
+var t, bass, treble;
 
 export function beforeRender(delta) {
-  t = time(0.05);
+  bass = (frequencyData[0] + frequencyData[1] + frequencyData[2]) / 3;
+  treble = 0;
+  for (var i = 20; i < 32; i++) treble += frequencyData[i];
+  treble /= 12;
+  t = time(0.05 + bass * 0.04);
 }
 
 export function render3D(index, x, y, z) {
   var angle = (atan2(y, x) + PI) / (2 * PI);
-  var bass = frequencyData[0] + frequencyData[1] + frequencyData[2];
-  var hue = angle * 4 - z / 16 - t;
-  var v = min(1, bass);
+  var hue = angle * 4 - z / 16 - t + treble;
+  var v = bass;
   hsv(hue, 1, v);
 }

--- a/patterns/SpectrumRings.js
+++ b/patterns/SpectrumRings.js
@@ -1,9 +1,14 @@
 export var frequencyData = array(32);
+var t;
+
+export function beforeRender(delta) {
+  t = time(0.02);
+}
 
 export function render3D(index, x, y, z) {
   var height = z / 16;
   var band = floor(height * 6);
-  var value = frequencyData[band] * 1.5;
-  var hue = band / 6;
+  var value = frequencyData[band] * 2;
+  var hue = band / 6 + t;
   hsv(hue, 1, min(1, value));
 }

--- a/patterns/SpiralPulse.js
+++ b/patterns/SpiralPulse.js
@@ -1,15 +1,18 @@
 export var frequencyData = array(32);
-var t;
+var t, bass, treble;
 
 export function beforeRender(delta) {
-  t = time(0.04);
+  bass = (frequencyData[0] + frequencyData[1] + frequencyData[2]) / 3;
+  treble = 0;
+  for (var i = 20; i < 32; i++) treble += frequencyData[i];
+  treble /= 12;
+  t = time(0.04 + treble * 0.04);
 }
 
 export function render3D(index, x, y, z) {
   var angle = (atan2(y, x) + PI) / (2 * PI);
   var height = z / 16;
-  var bass = frequencyData[0] + frequencyData[1] + frequencyData[2];
-  var hue = angle + height - t;
+  var hue = angle + height - t + treble;
   var v = min(1, bass * 2);
   hsv(hue, 1, v);
 }

--- a/patterns/TrebleSpark.js
+++ b/patterns/TrebleSpark.js
@@ -1,13 +1,15 @@
 export var frequencyData = array(32);
-var t;
+var t, bass, treble;
 
 export function beforeRender(delta) {
-  t = time(0.1);
+  bass = (frequencyData[0] + frequencyData[1] + frequencyData[2]) / 3;
+  treble = 0;
+  for (var i = 20; i < 32; i++) treble += frequencyData[i];
+  treble /= 12;
+  t = time(0.1 + treble * 0.05);
 }
 
 export function render3D(index, x, y, z) {
-  var treble = 0;
-  for (var i = 20; i < 32; i++) treble += frequencyData[i];
-  var v = random(1) < treble * 0.05 ? 1 : 0;
-  hsv(t + index / pixelCount, 1, v);
+  var v = random(1) < treble * 0.1 ? 1 : 0;
+  hsv(t + index / pixelCount + bass, 1, v);
 }

--- a/patterns/WaveFlow.js
+++ b/patterns/WaveFlow.js
@@ -1,13 +1,25 @@
 export var frequencyData = array(32);
-var t;
+var t, bass, mid, treble;
+
+function fract(x) {
+  return x - floor(x);
+}
 
 export function beforeRender(delta) {
-  var vol = 0;
-  for (var i = 0; i < 32; i++) vol += frequencyData[i];
+  bass = (frequencyData[0] + frequencyData[1] + frequencyData[2]) / 3;
+  mid = 0;
+  for (var i = 8; i < 20; i++) mid += frequencyData[i];
+  mid /= 12;
+  treble = 0;
+  for (var j = 20; j < 32; j++) treble += frequencyData[j];
+  treble /= 12;
+  var vol = bass + mid + treble;
   t = time(0.02 + vol * 0.05);
 }
 
 export function render3D(index, x, y, z) {
   var height = z / 16;
-  hsv(fract(height - t), 1, 1);
+  var hue = fract(height - t * (1 + bass));
+  var v = min(1, mid + treble);
+  hsv(hue, 1, v);
 }


### PR DESCRIPTION
## Summary
- make all patterns respond to bass, mid, and treble ranges with distinct behaviours
- add missing `fract` helper and fix WaveFlow brightness logic

## Testing
- `node --check patterns/*.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5e84b2078832891405cb56783d3c7